### PR TITLE
Prioritize P1 tickets in fallback analysis

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -340,12 +340,19 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
             
             return (priority_score + keyword_boost, -ticket.stale_days, -ticket.age_days)
         
-        sorted_tickets = sorted(tickets, key=ticket_urgency_score)
-        top = sorted_tickets[0]
-        
+        p1_tickets = [t for t in tickets if t.priority.startswith("P1")]
+        if p1_tickets:
+            top = sorted(p1_tickets, key=lambda t: (-t.stale_days, -t.age_days))[0]
+            sorted_tickets = sorted(tickets, key=ticket_urgency_score)
+        else:
+            sorted_tickets = sorted(tickets, key=ticket_urgency_score)
+            top = sorted_tickets[0]
+
         # Generate reasoning
         reasons = []
-        if top.priority in ['P1', 'Critical', 'High']:
+        if top.priority.startswith("P1"):
+            reasons.append("P1 priority")
+        elif top.priority in ['Critical', 'High']:
             reasons.append(f"{top.priority} priority")
         if top.stale_days > 30:
             reasons.append(f"stale for {top.stale_days} days")


### PR DESCRIPTION
## Summary
- Favor P1 tickets in fallback workload analysis and select the stalest and oldest among them
- Include explicit "P1 priority" reasoning when a P1 ticket is chosen

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b76f446074832b9119ab4f214dcf8a