### PR TITLE
Handle additional priority labels

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -328,8 +328,20 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
         
         # Prioritize by: P1 > security/failure keywords > staleness > age
         def ticket_urgency_score(ticket: Ticket) -> tuple:
-            priority_score = {'P1': 0, 'High': 1, 'Critical': 0, 'P2': 2, 'Medium': 3, 'P3': 4, 'Low': 5}.get(ticket.priority, 6)
-            
+            priority = (ticket.priority or "").strip().lower()
+            priority_score = {
+                'p0': -1,
+                'p1': 0,
+                'p1 - critical': 0,
+                'critical': 0,
+                'highest': 0,
+                'high': 1,
+                'p2': 2,
+                'medium': 3,
+                'p3': 4,
+                'low': 5,
+            }.get(priority, 6)
+
             # Security/failure keywords boost
             keywords = ['security', 'failure', 'critical', 'blocked', 'urgent', 'voc_feedback']
             keyword_boost = 0
@@ -337,7 +349,7 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
                 if keyword in ticket.summary.lower() or keyword in ticket.description.lower():
                     keyword_boost -= 2
                     break
-            
+
             return (priority_score + keyword_boost, -ticket.stale_days, -ticket.age_days)
         
         sorted_tickets = sorted(tickets, key=ticket_urgency_score)
@@ -345,8 +357,9 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
         
         # Generate reasoning
         reasons = []
-        if top.priority in ['P1', 'Critical', 'High']:
-            reasons.append(f"{top.priority} priority")
+        norm_priority = (top.priority or "").strip().lower()
+        if norm_priority in ['p0', 'p1', 'p1 - critical', 'critical', 'highest', 'high']:
+            reasons.append(f"{top.priority.strip()} priority")
         if top.stale_days > 30:
             reasons.append(f"stale for {top.stale_days} days")
         if 'failure' in top.summary.lower():

--- a/tests/test_priority_scores.py
+++ b/tests/test_priority_scores.py
@@ -1,0 +1,49 @@
+import unittest
+from datetime import datetime
+
+from assistant import LLMClient, Ticket
+
+
+class PriorityScoreTests(unittest.TestCase):
+    def setUp(self):
+        self.client = LLMClient()
+
+    def _make_ticket(self, key: str, priority: str) -> Ticket:
+        now = datetime.now()
+        return Ticket(
+            key=key,
+            summary="",
+            description="",
+            priority=priority,
+            status="Open",
+            assignee=None,
+            created=now,
+            updated=now,
+            comments_count=0,
+            labels=[],
+            issue_type="Bug",
+            raw_data={},
+        )
+
+    def test_highest_label(self):
+        high = self._make_ticket("H", "High")
+        highest = self._make_ticket("HI", " Highest ")
+        analysis = self.client._fallback_analysis([high, highest])
+        self.assertEqual(analysis.top_priority.key, "HI")
+
+    def test_p1_critical_label(self):
+        high = self._make_ticket("H", "High")
+        critical = self._make_ticket("C", "p1 - critical")
+        analysis = self.client._fallback_analysis([high, critical])
+        self.assertEqual(analysis.top_priority.key, "C")
+
+    def test_p0_label(self):
+        p1 = self._make_ticket("P1", "P1")
+        p0 = self._make_ticket("P0", "p0")
+        analysis = self.client._fallback_analysis([p1, p0])
+        self.assertEqual(analysis.top_priority.key, "P0")
+
+
+if __name__ == "__main__":
+    unittest.main()
+


### PR DESCRIPTION
## Summary
- Normalize ticket priority strings once and handle additional labels like "Highest", "P1 - Critical", and "P0" in fallback analysis
- Recognize high-priority labels during reasoning for clearer explanations
- Add unit tests to verify new priority labels rank correctly

## Testing
- `python -m unittest discover -s tests`


------
https://chatgpt.com/codex/tasks/task_e_68b76f4aaeec832bb9b83185665de08d