### PR TITLE
Add suggestion caching with refresh control

### DIFF
--- a/cache.py
+++ b/cache.py
@@ -1,0 +1,29 @@
+import os
+import json
+from typing import Any, Dict, Optional
+
+class Cache:
+    """Simple JSON file-based cache."""
+    def __init__(self, filename: Optional[str] = None) -> None:
+        self.filename = filename or os.getenv("CACHE_FILE", ".cache.json")
+        self._cache: Dict[str, Dict[str, Any]] = {}
+        self._load()
+
+    def _load(self) -> None:
+        if os.path.exists(self.filename):
+            try:
+                with open(self.filename, "r", encoding="utf-8") as f:
+                    self._cache = json.load(f)
+            except Exception:
+                self._cache = {}
+
+    def _save(self) -> None:
+        with open(self.filename, "w", encoding="utf-8") as f:
+            json.dump(self._cache, f)
+
+    def get(self, key: str) -> Optional[Dict[str, Any]]:
+        return self._cache.get(key)
+
+    def set(self, key: str, value: Dict[str, Any]) -> None:
+        self._cache[key] = value
+        self._save()

--- a/tests/test_suggestion_cache.py
+++ b/tests/test_suggestion_cache.py
@@ -1,0 +1,75 @@
+import os
+import json
+import unittest
+from datetime import datetime, timedelta
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from assistant import LLMClient, Ticket
+
+class SuggestionCacheTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["CACHE_FILE"] = "test_cache.json"
+        os.environ["LLM_PROVIDER"] = "openai"
+        try:
+            os.remove("test_cache.json")
+        except FileNotFoundError:
+            pass
+        self.client = LLMClient()
+        now = datetime.now()
+        self.ticket = Ticket(
+            key="T1",
+            summary="",
+            description="",
+            priority="P1",
+            status="Open",
+            assignee=None,
+            created=now,
+            updated=now,
+            comments_count=0,
+            labels=[],
+            issue_type="Bug",
+            raw_data={},
+        )
+
+    def tearDown(self):
+        if os.path.exists("test_cache.json"):
+            os.remove("test_cache.json")
+        del os.environ["CACHE_FILE"]
+        del os.environ["LLM_PROVIDER"]
+
+    def _mock_resp(self, text: str):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=text))])
+
+    def test_cached_suggestion_reused(self):
+        with patch("assistant.openai.chat.completions.create", return_value=self._mock_resp("first")) as mock_create:
+            first = self.client.suggest_action(self.ticket, "ctx")
+            second = self.client.suggest_action(self.ticket, "ctx")
+            self.assertEqual(first, "first")
+            self.assertEqual(second, "first")
+            self.assertEqual(mock_create.call_count, 1)
+
+    def test_force_refresh(self):
+        responses = [self._mock_resp("first"), self._mock_resp("second")]
+        with patch("assistant.openai.chat.completions.create", side_effect=responses) as mock_create:
+            first = self.client.suggest_action(self.ticket, "ctx")
+            second = self.client.suggest_action(self.ticket, "ctx", force_refresh=True)
+            self.assertEqual(first, "first")
+            self.assertEqual(second, "second")
+            self.assertEqual(mock_create.call_count, 2)
+
+    def test_cache_expiration(self):
+        responses = [self._mock_resp("first"), self._mock_resp("second")]
+        with patch("assistant.openai.chat.completions.create", side_effect=responses) as mock_create:
+            first = self.client.suggest_action(self.ticket, "ctx")
+            key = f"{self.ticket.key}:ctx"
+            cached = self.client.cache.get(key)
+            cached["timestamp"] = (datetime.now() - timedelta(hours=25)).isoformat()
+            self.client.cache.set(key, cached)
+            second = self.client.suggest_action(self.ticket, "ctx")
+            self.assertEqual(first, "first")
+            self.assertEqual(second, "second")
+            self.assertEqual(mock_create.call_count, 2)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- cache ticket suggestions using JSON-based Cache keyed by ticket key and context
- reuse cached suggestions if younger than 24h with optional force refresh
- cover caching, refresh, and expiration logic with unit tests and ensure P0 priority handling

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b77362251c832b8ed8e78827755c1b