### PR TITLE
Add refresh command to rerun analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ Let me analyze your current workload...
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 💬 Let's work together! What would you like to do?
-Commands: 'focus <ticket>', 'help <ticket>', 'list', 'comment <ticket>', 'quit'
+Commands: 'focus <ticket>', 'help <ticket>', 'list', 'comment <ticket>', 'refresh', 'quit'
 
 What should we tackle? help SEC-2847
 
@@ -89,6 +89,7 @@ I can help you with SEC-2847 in these ways:
 - `focus <ticket>` - Get detailed analysis of a specific ticket
 - `help <ticket>` - Get AI suggestions and offers to help with actions
 - `comment <ticket>` - Draft and post a comment with AI assistance
+- `refresh` - Re-run workload analysis
 - `quit` - End your work session
 
 ## Configuration Details

--- a/assistant.py
+++ b/assistant.py
@@ -5,6 +5,7 @@ import os
 import json
 import requests
 import re
+import hashlib
 from datetime import datetime, timedelta
 from typing import List, Dict, Optional, Any
 from dataclasses import dataclass
@@ -352,13 +353,8 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
 
             return (priority_score + keyword_boost, -ticket.stale_days, -ticket.age_days)
         
-        p1_tickets = [t for t in tickets if t.priority.startswith("P1")]
-        if p1_tickets:
-            top = sorted(p1_tickets, key=lambda t: (-t.stale_days, -t.age_days))[0]
-            sorted_tickets = sorted(tickets, key=ticket_urgency_score)
-        else:
-            sorted_tickets = sorted(tickets, key=ticket_urgency_score)
-            top = sorted_tickets[0]
+        sorted_tickets = sorted(tickets, key=ticket_urgency_score)
+        top = sorted_tickets[0]
 
         # Generate reasoning
         reasons = []
@@ -463,7 +459,14 @@ class WorkAssistant:
         self.current_analysis: Optional[WorkloadAnalysis] = None
         self.current_focus: Optional[Ticket] = None
         self.last_user_input: str = ""
-    
+        self.analysis_cache: Dict[str, WorkloadAnalysis] = {}
+        self.current_ticket_hash: Optional[str] = None
+
+    def _calculate_ticket_hash(self, tickets: List[Ticket]) -> str:
+        """Create a hash representing the current ticket set"""
+        hash_input = "|".join(sorted(f"{t.key}:{t.updated.isoformat()}" for t in tickets))
+        return hashlib.sha256(hash_input.encode()).hexdigest()
+
     def start_session(self):
         """Begin a work session"""
         console.print("\n🎯 Personal AI Work Assistant", style="bold blue")
@@ -472,21 +475,29 @@ class WorkAssistant:
         # Fetch tickets
         with console.status("[bold green]Fetching your tickets..."):
             self.current_tickets = self.jira.get_my_tickets()
-        
+
         if not self.current_tickets:
             console.print("No open tickets found. Time to take a break! ☕", style="green")
             return
-        
-        # Get AI analysis
-        with console.status("[bold green]Analyzing priorities..."):
-            self.current_analysis = self.llm.analyze_workload(self.current_tickets)
+
+        # Determine ticket hash for caching
+        self.current_ticket_hash = self._calculate_ticket_hash(self.current_tickets)
+
+        # Get AI analysis (use cache when available)
+        cached = self.analysis_cache.get(self.current_ticket_hash)
+        if cached:
+            self.current_analysis = cached
+        else:
+            with console.status("[bold green]Analyzing priorities..."):
+                self.current_analysis = self.llm.analyze_workload(self.current_tickets)
+            self.analysis_cache[self.current_ticket_hash] = self.current_analysis
         
         # Display the analysis
         self._display_analysis()
         
         # Start interactive session
         self._interactive_session()
-    
+
     def _display_analysis(self):
         """Display the AI workload analysis"""
         if not self.current_analysis:
@@ -533,12 +544,30 @@ Why it's urgent: {analysis.priority_reasoning}"""
                 title_align="left",
                 border_style="green"
             ))
-    
+
+    def _refresh_analysis(self):
+        """Clear cached analysis and recompute"""
+        if self.current_ticket_hash and self.current_ticket_hash in self.analysis_cache:
+            del self.analysis_cache[self.current_ticket_hash]
+
+        console.print("\n🔄 Refreshing workload analysis...")
+
+        with console.status("[bold green]Fetching your tickets..."):
+            self.current_tickets = self.jira.get_my_tickets()
+
+        with console.status("[bold green]Analyzing priorities..."):
+            self.current_analysis = self.llm.analyze_workload(self.current_tickets)
+
+        self.current_ticket_hash = self._calculate_ticket_hash(self.current_tickets)
+        self.analysis_cache[self.current_ticket_hash] = self.current_analysis
+
+        self._display_analysis()
+
     def _interactive_session(self):
         """Handle interactive conversation with the user"""
         console.print("\n" + "="*60)
         console.print("💬 Let's work together! What would you like to do?")
-        console.print("Commands: 'focus <ticket>', 'help <ticket>', 'list', 'comment <ticket>', 'quit'")
+        console.print("Commands: 'focus <ticket>', 'help <ticket>', 'list', 'comment <ticket>', 'refresh', 'quit'")
         console.print("="*60 + "\n")
         
         while True:
@@ -573,7 +602,12 @@ Why it's urgent: {analysis.priority_reasoning}"""
         if input_lower == 'list':
             self._list_tickets()
             return False
-        
+
+        # Refresh analysis
+        if input_lower in ['refresh', 're analyze', 're-analyze', 'reanalyze']:
+            self._refresh_analysis()
+            return False
+
         # Smart command parsing
         if input_lower.startswith('focus '):
             ticket_key = user_input[6:].strip()
@@ -814,9 +848,10 @@ Focus on progress, next steps, or findings based on the context provided."""
 
 Basic Commands:
 • list - Show all your tickets in a table
-• focus <ticket-key> - Get detailed analysis of a specific ticket  
+• focus <ticket-key> - Get detailed analysis of a specific ticket
 • help <ticket-key> - Get AI assistance and action suggestions
 • comment <ticket-key> - Draft and post a comment with AI help
+• refresh - Re-run workload analysis
 • quit - End the session
 
 Smart Commands:

--- a/config_files.sh
+++ b/config_files.sh
@@ -103,7 +103,7 @@ Let me analyze your current workload...
 ┗━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━┛
 
 💬 Let's work together! What would you like to do?
-Commands: 'focus <ticket>', 'help <ticket>', 'list', 'comment <ticket>', 'quit'
+Commands: 'focus <ticket>', 'help <ticket>', 'list', 'comment <ticket>', 'refresh', 'quit'
 
 What should we tackle? help SEC-2847
 
@@ -123,6 +123,7 @@ I can help you with SEC-2847 in these ways:
 - `focus <ticket>` - Get detailed analysis of a specific ticket
 - `help <ticket>` - Get AI suggestions and offers to help with actions
 - `comment <ticket>` - Draft and post a comment with AI assistance
+- `refresh` - Re-run workload analysis
 - `quit` - End your work session
 
 ## Configuration Details


### PR DESCRIPTION
## Summary
- allow `refresh`/`re analyze` commands to clear cached workload analysis and recompute
- document refresh command in CLI help and README
- fix fallback priority ordering so P0 tickets outrank P1

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b773607b1c832bb1cc11d3c28313b4