### PR TITLE
Add session resume prompt and fresh scan option

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -203,6 +203,7 @@ class LLMClient:
     def __init__(self):
         self.provider = os.getenv('LLM_PROVIDER', 'openai')
         self.cache = Cache()
+        self.semantic_cache = SemanticCache()
         
         if self.provider == 'openai':
             openai.api_key = os.getenv('OPENAI_API_KEY')
@@ -211,8 +212,6 @@ class LLMClient:
             self.ollama_host = os.getenv('OLLAMA_HOST', 'http://localhost:11434')
             self.model = os.getenv('OLLAMA_MODEL', 'llama3.1')
 
-        self.cache = SemanticCache()
-    
         # Cache for the last workload analysis
         self._analysis_cache: Optional[WorkloadAnalysis] = None
         self._cache_time: Optional[datetime] = None
@@ -260,7 +259,7 @@ class LLMClient:
         ticket_hash_source = json.dumps(sorted_tickets, sort_keys=True, default=str)
         ticket_hash = hashlib.sha256(ticket_hash_source.encode('utf-8')).hexdigest()
 
-        cached = self.cache.get(ticket_hash)
+        cached = self.semantic_cache.get(ticket_hash)
         if cached:
             ts = datetime.fromisoformat(cached["timestamp"])
             if datetime.now() - ts < timedelta(hours=24):
@@ -312,7 +311,7 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
                     "stream": False
                 })
                 analysis_text = response.json()["response"]
-            self.cache.set(ticket_hash, analysis_text)
+            self.semantic_cache.set(ticket_hash, analysis_text)
             # Extract the recommended ticket key from AI response
             recommended_ticket = self._extract_recommended_ticket(analysis_text, tickets)
 
@@ -535,13 +534,24 @@ class WorkAssistant:
         self.last_user_input: str = ""
         self.analysis_cache: Dict[str, WorkloadAnalysis] = {}
         self.current_ticket_hash: Optional[str] = None
+        self.session_cache = Cache()
+        self.saved_focus_key: Optional[str] = None
+
+    def load_state(self):
+        """Load persisted session state"""
+        data = self.session_cache.get("session") or {}
+        self.saved_focus_key = data.get("current_focus")
+
+    def save_state(self):
+        """Persist current focus ticket"""
+        self.session_cache.set("session", {"current_focus": self.current_focus.key if self.current_focus else None})
 
     def _calculate_ticket_hash(self, tickets: List[Ticket]) -> str:
         """Create a hash representing the current ticket set"""
         hash_input = "|".join(sorted(f"{t.key}:{t.updated.isoformat()}" for t in tickets))
         return hashlib.sha256(hash_input.encode()).hexdigest()
 
-    def start_session(self):
+    def start_session(self, resume: bool = False):
         """Begin a work session"""
         console.print("\n🎯 Personal AI Work Assistant", style="bold blue")
         console.print("Let me analyze your current workload...\n")
@@ -568,9 +578,21 @@ class WorkAssistant:
         
         # Display the analysis
         self._display_analysis()
-        
+
+        if resume and self.saved_focus_key:
+            self._focus_on_ticket(self.saved_focus_key)
+
         # Start interactive session
         self._interactive_session()
+
+    def fresh_scan(self):
+        """Force ticket retrieval and fresh analysis"""
+        self.llm.clear_cache()
+        self.analysis_cache = {}
+        self.current_focus = None
+        self.saved_focus_key = None
+        self.save_state()
+        self.start_session()
 
     def _display_analysis(self):
         """Display the AI workload analysis"""
@@ -623,6 +645,8 @@ Why it's urgent: {analysis.priority_reasoning}"""
         """Clear cached analysis and recompute"""
         if self.current_ticket_hash and self.current_ticket_hash in self.analysis_cache:
             del self.analysis_cache[self.current_ticket_hash]
+
+        self.llm.clear_cache()
 
         console.print("\n🔄 Refreshing workload analysis...")
 
@@ -875,8 +899,9 @@ Why it's urgent: {analysis.priority_reasoning}"""
         if not ticket:
             console.print(f"❌ Couldn't find ticket '{ticket_key}'. Try 'list' to see available tickets.", style="red")
             return
-        
+
         self.current_focus = ticket
+        self.save_state()
         console.print(f"\n🔍 Focusing on {ticket.key}...")
         
         # Show ticket details with proper description formatting
@@ -908,8 +933,9 @@ Description:
         if not ticket:
             console.print(f"❌ Couldn't find ticket '{ticket_key}'", style="red")
             return
-        
+
         self.current_focus = ticket
+        self.save_state()
         console.print(f"\n🆘 Getting help for {ticket.key}...")
         
         with console.status("[bold green]Analyzing ticket and generating help..."):
@@ -1093,10 +1119,21 @@ def main():
         console.print("The assistant will still work with basic analysis.", style="yellow")
     elif llm_provider == 'ollama':
         console.print("🤖 Using Ollama for AI features. Make sure it's running locally.", style="blue")
-    
+
     try:
         assistant = WorkAssistant()
-        assistant.start_session()
+        assistant.load_state()
+        if assistant.saved_focus_key:
+            choice = Prompt.ask(
+                f"Resume work on {assistant.saved_focus_key} or scan for new tickets?",
+                choices=["resume", "scan"],
+            )
+            if choice == "resume":
+                assistant.start_session(resume=True)
+            else:
+                assistant.fresh_scan()
+        else:
+            assistant.fresh_scan()
     except KeyboardInterrupt:
         console.print("\n👋 Session interrupted. See you later!", style="yellow")
     except Exception as e:


### PR DESCRIPTION
## Summary
- Persist current ticket focus between sessions and allow resuming via prompt
- Introduce `fresh_scan` to force ticket refresh and analysis
- Separate semantic and suggestion caches in LLM client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b777114ae4832b9b664579e37cf6cd