### PR TITLE
feat: add session manager with scan resume logic

### DIFF
--- a/session_manager.py
+++ b/session_manager.py
@@ -1,0 +1,57 @@
+import os
+from datetime import datetime, timedelta
+from typing import Any, Dict, List, Optional
+from dataclasses import asdict, is_dataclass
+
+from cache import Cache
+
+
+class SessionManager:
+    """Manage persisted session data including last scan timestamp."""
+
+    def __init__(self, cache: Optional[Cache] = None) -> None:
+        # Use separate file to avoid clashing with other cache data
+        self.cache = cache or Cache(filename=os.getenv("SESSION_FILE", "session_cache.json"))
+        data = self.cache.get("session") or {}
+        self.last_scan: Optional[datetime] = None
+        if data.get("last_scan"):
+            try:
+                self.last_scan = datetime.fromisoformat(data["last_scan"])
+            except ValueError:
+                self.last_scan = None
+        self._tickets: List[Dict[str, Any]] = data.get("tickets", [])
+
+    def _serialize_ticket(self, ticket: Any) -> Dict[str, Any]:
+        data = asdict(ticket) if is_dataclass(ticket) else dict(ticket)
+        if isinstance(data.get("created"), datetime):
+            data["created"] = data["created"].isoformat()
+        if isinstance(data.get("updated"), datetime):
+            data["updated"] = data["updated"].isoformat()
+        return data
+
+    def update_session(self, tickets: List[Any]) -> None:
+        """Store tickets and update the last_scan timestamp."""
+        self.last_scan = datetime.now()
+        self._tickets = [self._serialize_ticket(t) for t in tickets]
+        self.cache.set(
+            "session",
+            {
+                "last_scan": self.last_scan.isoformat(),
+                "tickets": self._tickets,
+            },
+        )
+
+    def needs_rescan(self) -> bool:
+        if not self.last_scan:
+            return True
+        return datetime.now() - self.last_scan > timedelta(hours=24)
+
+    def get_tickets(self) -> List[Dict[str, Any]]:
+        return self._tickets
+
+    def get_ticket_summary(self) -> str:
+        if not self._tickets:
+            return "No tickets stored."
+        first = ", ".join(t["key"] for t in self._tickets[:3])
+        more = "" if len(self._tickets) <= 3 else f", +{len(self._tickets) - 3} more"
+        return f"Last session had {len(self._tickets)} tickets: {first}{more}."

--- a/tests/test_session_manager.py
+++ b/tests/test_session_manager.py
@@ -1,0 +1,107 @@
+import os
+import sys
+import unittest
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from assistant import Ticket, WorkAssistant, WorkloadAnalysis
+from session_manager import SessionManager
+from cache import Cache
+
+
+class SessionManagerTests(unittest.TestCase):
+    def setUp(self):
+        now = datetime.now()
+        self.ticket = Ticket(
+            key="T1",
+            summary="s",
+            description="d",
+            priority="P2",
+            status="Open",
+            assignee=None,
+            created=now,
+            updated=now,
+            comments_count=0,
+            labels=[],
+            issue_type="Bug",
+            raw_data={},
+        )
+        self.ticket_dict = {
+            "key": "T1",
+            "summary": "s",
+            "description": "d",
+            "priority": "P2",
+            "status": "Open",
+            "assignee": None,
+            "created": now.isoformat(),
+            "updated": now.isoformat(),
+            "comments_count": 0,
+            "labels": [],
+            "issue_type": "Bug",
+            "raw_data": {},
+        }
+        self.cache_file = "test_session.json"
+        if os.path.exists(self.cache_file):
+            os.remove(self.cache_file)
+
+    def tearDown(self):
+        if os.path.exists(self.cache_file):
+            os.remove(self.cache_file)
+
+    def test_last_scan_persisted(self):
+        sm = SessionManager(cache=Cache(self.cache_file))
+        self.assertIsNone(sm.last_scan)
+        sm.update_session([self.ticket])
+        self.assertIsNotNone(sm.last_scan)
+        sm2 = SessionManager(cache=Cache(self.cache_file))
+        self.assertIsNotNone(sm2.last_scan)
+
+    def test_start_session_uses_cached_when_recent(self):
+        cache = Cache(self.cache_file)
+        cache.set("session", {"last_scan": datetime.now().isoformat(), "tickets": [self.ticket_dict]})
+        sm = SessionManager(cache)
+        jira = MagicMock()
+        llm = MagicMock()
+        llm.analyze_workload.return_value = WorkloadAnalysis(
+            top_priority=self.ticket,
+            priority_reasoning="",
+            next_steps=[],
+            can_help_with=[],
+            other_notable=[],
+            summary="",
+        )
+        assistant = WorkAssistant(jira_client=jira, llm_client=llm, session_manager=sm)
+        assistant._display_analysis = MagicMock()
+        assistant._interactive_session = MagicMock()
+        with patch("assistant.Confirm.ask", return_value=True):
+            assistant.start_session()
+        jira.get_my_tickets.assert_not_called()
+
+    def test_start_session_rescans_when_old(self):
+        cache = Cache(self.cache_file)
+        old_time = datetime.now() - timedelta(hours=25)
+        cache.set("session", {"last_scan": old_time.isoformat(), "tickets": [self.ticket_dict]})
+        sm = SessionManager(cache)
+        jira = MagicMock()
+        jira.get_my_tickets.return_value = [self.ticket]
+        llm = MagicMock()
+        llm.analyze_workload.return_value = WorkloadAnalysis(
+            top_priority=self.ticket,
+            priority_reasoning="",
+            next_steps=[],
+            can_help_with=[],
+            other_notable=[],
+            summary="",
+        )
+        assistant = WorkAssistant(jira_client=jira, llm_client=llm, session_manager=sm)
+        assistant._display_analysis = MagicMock()
+        assistant._interactive_session = MagicMock()
+        with patch("assistant.Confirm.ask", return_value=True):
+            assistant.start_session()
+        jira.get_my_tickets.assert_called_once()
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add SessionManager to persist tickets and last scan timestamp
- resume recent sessions or re-scan after 24h
- update refresh logic and cover with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7770ed7bc832ba5c3fb1af72ee27a