### PR TITLE
Add dependency analysis and caching

### DIFF
--- a/session_manager.py
+++ b/session_manager.py
@@ -19,6 +19,7 @@ class SessionManager:
             "tickets": [],
             "ticket_progress": {},
             "conversation_history": [],
+            "dependencies": {},
         }
         self.load()
 
@@ -75,6 +76,13 @@ class SessionManager:
         history.append(message)
         self.save()
 
+    def set_dependencies(self, deps: Dict[str, List[str]]) -> None:
+        self.data["dependencies"] = deps
+        self.save()
+
+    def get_dependencies(self) -> Dict[str, List[str]]:
+        return dict(self.data.get("dependencies", {}))
+
     def reset(self) -> None:
         self.data.update(
             {
@@ -83,6 +91,7 @@ class SessionManager:
                 "tickets": [],
                 "ticket_progress": {},
                 "conversation_history": [],
+                "dependencies": {},
             }
         )
         self.save()


### PR DESCRIPTION
## Summary
- add `LLMClient.analyze_dependencies` to detect cross-ticket references
- surface dependency panel in session start and cache results in session manager
- test dependency detection and cached reuse

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7caa7cae8832b8cc3c6b538bc01f5