### PR TITLE
Add Slack notification support

### DIFF
--- a/.env
+++ b/.env
@@ -17,3 +17,9 @@ OPENAI_MODEL=gpt-4  # or gpt-3.5-turbo for cheaper option
 # Ollama Configuration (if using local Ollama)
 OLLAMA_HOST=http://localhost:11434
 OLLAMA_MODEL=qwen3:14b  # or codestral, llama2, etc.
+
+# Slack Configuration (optional)
+# Provide either a webhook URL or an API token.
+# SLACK_WEBHOOK_URL=https://hooks.slack.com/services/XXX/YYY/ZZZ
+# SLACK_API_TOKEN=xoxb-your-slack-token
+# SLACK_DEFAULT_CHANNEL=#general

--- a/assistant.py
+++ b/assistant.py
@@ -20,6 +20,7 @@ import openai
 from dotenv import load_dotenv
 from cache import Cache, SemanticCache
 from session_manager import SessionManager
+from integrations.slack_client import SlackClient
 
 # Load environment variables
 load_dotenv()
@@ -586,10 +587,17 @@ Keep response conversational and focused on getting this done."""
 # ==============================================================================
 
 class WorkAssistant:
-    def __init__(self, jira_client: Optional[JiraClient] = None, llm_client: Optional[LLMClient] = None, session_manager: Optional[SessionManager] = None):
+    def __init__(
+        self,
+        jira_client: Optional[JiraClient] = None,
+        llm_client: Optional[LLMClient] = None,
+        session_manager: Optional[SessionManager] = None,
+        slack_client: Optional[SlackClient] = None,
+    ):
         self.session = session_manager or SessionManager()
         self.jira = jira_client or JiraClient()
         self.llm = llm_client or LLMClient()
+        self.slack = slack_client
         self.current_tickets: List[Ticket] = []
         self.current_analysis: Optional[WorkloadAnalysis] = None
         self.current_focus: Optional[Ticket] = None
@@ -940,6 +948,11 @@ Why it's urgent: {analysis.priority_reasoning}"""
             self._help_with_comment(ticket_key)
             return False
 
+        if input_lower.startswith('notify '):
+            ticket_key = user_input[7:].strip()
+            self._notify_ticket(ticket_key)
+            return False
+
         if input_lower in ['re analyze', 'reanalyze', 're-analyze']:
             console.print("🔁 Re-analyzing your workload...")
             self.llm.clear_cache()
@@ -1001,6 +1014,27 @@ Why it's urgent: {analysis.priority_reasoning}"""
             console.print("💡 Try: '2'/'list' to see your tickets, or 'help' for available commands")
 
         return False
+
+    def _notify_ticket(self, ticket_key: str):
+        """Send a Slack notification about a ticket"""
+        ticket = self._find_ticket(ticket_key)
+        if not ticket:
+            console.print(f"❌ Couldn't find ticket '{ticket_key}'. Try 'list' to see available tickets.", style="red")
+            return
+        message = (
+            f"*{ticket.key}* - {ticket.summary}\n"
+            f"Priority: {ticket.priority} | Status: {ticket.status}\n"
+            f"{os.getenv('JIRA_BASE_URL', '').rstrip('/')}/browse/{ticket.key}"
+        )
+        try:
+            if not self.slack:
+                self.slack = SlackClient()
+            if self.slack.send_message(message):
+                console.print("✅ Notification sent to Slack", style="green")
+            else:
+                console.print("⚠️ Failed to send Slack notification", style="yellow")
+        except Exception as e:
+            console.print(f"❌ Slack notification error: {e}", style="red")
 
     def _open_ticket(self, ticket_key: str):
         """Print the Jira URL for a ticket, to open manually"""
@@ -1274,6 +1308,7 @@ Basic Commands:
 • focus <ticket-key> - Get detailed analysis of a specific ticket
 • help <ticket-key> - Get AI assistance and action suggestions
 • comment <ticket-key> - Draft and post a comment with AI help
+• notify <ticket-key> - Send ticket summary to Slack
 • refresh - Re-run workload analysis
 • open <ticket-key> - Print the Jira URL to open in browser
 • health - Run environment and connectivity checks

--- a/integrations/slack_client.py
+++ b/integrations/slack_client.py
@@ -1,0 +1,42 @@
+import os
+from typing import Optional
+
+import requests
+
+
+class SlackClient:
+    """Simple Slack client supporting webhook or API token."""
+
+    def __init__(self, webhook_url: Optional[str] = None, api_token: Optional[str] = None):
+        self.webhook_url = webhook_url or os.getenv("SLACK_WEBHOOK_URL")
+        self.api_token = api_token or os.getenv("SLACK_API_TOKEN")
+        self.default_channel = os.getenv("SLACK_DEFAULT_CHANNEL")
+
+        if not self.webhook_url and not self.api_token:
+            raise ValueError("Slack webhook URL or API token must be provided")
+
+    def send_message(self, message: str, channel: Optional[str] = None) -> bool:
+        """Send a message via webhook or API token."""
+        if self.webhook_url:
+            payload = {"text": message}
+            response = requests.post(self.webhook_url, json=payload)
+            response.raise_for_status()
+            return response.status_code == 200
+
+        if self.api_token:
+            channel = channel or self.default_channel
+            if not channel:
+                raise ValueError("Slack channel required when using API token")
+
+            headers = {
+                "Authorization": f"Bearer {self.api_token}",
+                "Content-Type": "application/json",
+            }
+            payload = {"channel": channel, "text": message}
+            url = "https://slack.com/api/chat.postMessage"
+            response = requests.post(url, headers=headers, json=payload)
+            response.raise_for_status()
+            data = response.json()
+            return bool(data.get("ok"))
+
+        return False

--- a/tests/test_notify_command.py
+++ b/tests/test_notify_command.py
@@ -1,0 +1,42 @@
+from datetime import datetime
+
+from assistant import WorkAssistant, Ticket
+
+
+class DummySlack:
+    def __init__(self):
+        self.messages = []
+
+    def send_message(self, message, channel=None):
+        self.messages.append(message)
+        return True
+
+
+class Dummy:
+    pass
+
+
+def test_notify_formats_message(monkeypatch):
+    ticket = Ticket(
+        key="ABC-123",
+        summary="Test summary",
+        description="Desc",
+        priority="High",
+        status="Open",
+        assignee=None,
+        created=datetime.now(),
+        updated=datetime.now(),
+        comments_count=0,
+        labels=[],
+        issue_type="Bug",
+        raw_data={},
+    )
+
+    slack = DummySlack()
+    wa = WorkAssistant(Dummy(), Dummy(), Dummy(), slack_client=slack)
+    wa.current_tickets = [ticket]
+    wa._notify_ticket("ABC-123")
+    assert slack.messages, "No message sent"
+    sent = slack.messages[0]
+    assert "ABC-123" in sent
+    assert "Test summary" in sent

--- a/tests/test_slack_client.py
+++ b/tests/test_slack_client.py
@@ -1,0 +1,58 @@
+import os
+from integrations.slack_client import SlackClient
+
+
+def test_webhook_sends_payload(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json=None, headers=None):
+        calls['url'] = url
+        calls['json'] = json
+
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+        return Resp()
+
+    monkeypatch.setenv('SLACK_WEBHOOK_URL', 'https://hooks.slack.com/services/T000/B000/XXX')
+    monkeypatch.delenv('SLACK_API_TOKEN', raising=False)
+    monkeypatch.setattr('requests.post', fake_post)
+
+    client = SlackClient()
+    assert client.send_message('hello world')
+    assert calls['url'] == 'https://hooks.slack.com/services/T000/B000/XXX'
+    assert calls['json'] == {'text': 'hello world'}
+
+
+def test_api_token_sends_payload(monkeypatch):
+    calls = {}
+
+    def fake_post(url, json=None, headers=None):
+        calls['url'] = url
+        calls['json'] = json
+        calls['headers'] = headers
+
+        class Resp:
+            status_code = 200
+
+            def raise_for_status(self):
+                pass
+
+            def json(self):
+                return {'ok': True}
+
+        return Resp()
+
+    monkeypatch.delenv('SLACK_WEBHOOK_URL', raising=False)
+    monkeypatch.setenv('SLACK_API_TOKEN', 'xoxb-test')
+    monkeypatch.setenv('SLACK_DEFAULT_CHANNEL', '#general')
+    monkeypatch.setattr('requests.post', fake_post)
+
+    client = SlackClient()
+    assert client.send_message('hi there')
+    assert calls['url'] == 'https://slack.com/api/chat.postMessage'
+    assert calls['json'] == {'channel': '#general', 'text': 'hi there'}
+    assert calls['headers']['Authorization'] == 'Bearer xoxb-test'


### PR DESCRIPTION
## Summary
- add SlackClient supporting webhook or API token messaging
- add `notify <ticket>` command to send ticket summaries to Slack
- document Slack configuration variables in `.env`
- test Slack client and notify command with mocked requests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7caa91808832b9f37dc3987d65f8b