### PR TITLE
Log work patterns and tailor workload analysis

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -202,11 +202,15 @@ class JiraClient:
 # ==============================================================================
 
 class LLMClient:
-    def __init__(self):
+    def __init__(self, session_manager: Optional[SessionManager] = None):
         self.provider = os.getenv('LLM_PROVIDER', 'openai')
         # Cache for per-ticket suggestions
         self.cache = Cache()
         self.semantic_cache = SemanticCache()
+        self.session = session_manager
+        self.work_patterns: Dict[str, Dict[str, int]] = {}
+        if self.session:
+            self.work_patterns = self.session.get_work_patterns()
         
 
         if self.provider == 'openai':
@@ -232,6 +236,13 @@ class LLMClient:
     def analyze_workload(self, tickets: List[Ticket]) -> WorkloadAnalysis:
         """Return cached workload analysis when valid."""
 
+        if self.session:
+            self.session.log_command("analyze_workload")
+            for t in tickets:
+                if t.issue_type:
+                    self.session.log_ticket_category(t.issue_type)
+            self.work_patterns = self.session.get_work_patterns()
+
         if (
             self._analysis_cache
             and self._cache_time
@@ -239,12 +250,12 @@ class LLMClient:
         ):
             return self._analysis_cache
 
-        analysis = self._compute_analysis(tickets)
+        analysis = self._compute_analysis(tickets, self.work_patterns)
         self._analysis_cache = analysis
         self._cache_time = datetime.now()
         return analysis
 
-    def _compute_analysis(self, tickets: List[Ticket]) -> WorkloadAnalysis:
+    def _compute_analysis(self, tickets: List[Ticket], patterns: Optional[Dict[str, Dict[str, int]]] = None) -> WorkloadAnalysis:
         """Get AI analysis of your ticket workload"""
         
         # Prepare ticket data for analysis
@@ -292,11 +303,17 @@ class LLMClient:
                     recommended_ticket = self._extract_recommended_ticket(analysis_text, tickets)
                 return self._parse_analysis(analysis_text, tickets, recommended_ticket)
 
+        category_focus = ""
+        if patterns and patterns.get("categories"):
+            sorted_cats = sorted(patterns["categories"].items(), key=lambda x: x[1], reverse=True)
+            cat_list = ", ".join(cat for cat, _ in sorted_cats)
+            category_focus = f"\nThe user frequently works on: {cat_list}. Prioritize these categories when relevant.\n"
+
         prompt = f"""You are my intelligent work assistant. I have {len(tickets)} open tickets that need attention.
 
 My tickets:
 {json.dumps(ticket_summaries, indent=2, default=str)}
-
+{category_focus}
 Please analyze my workload and help me prioritize. Be conversational and helpful, like a smart colleague.
 
 IMPORTANT PRIORITY RULES:
@@ -589,7 +606,7 @@ class WorkAssistant:
     def __init__(self, jira_client: Optional[JiraClient] = None, llm_client: Optional[LLMClient] = None, session_manager: Optional[SessionManager] = None):
         self.session = session_manager or SessionManager()
         self.jira = jira_client or JiraClient()
-        self.llm = llm_client or LLMClient()
+        self.llm = llm_client or LLMClient(session_manager=self.session)
         self.current_tickets: List[Ticket] = []
         self.current_analysis: Optional[WorkloadAnalysis] = None
         self.current_focus: Optional[Ticket] = None

--- a/tests/test_work_patterns.py
+++ b/tests/test_work_patterns.py
@@ -1,0 +1,58 @@
+import openai
+from datetime import datetime
+from assistant import LLMClient, Ticket
+from session_manager import SessionManager
+
+
+def test_work_patterns_persist(tmp_path):
+    state_file = tmp_path / "state.json"
+    sm1 = SessionManager(str(state_file))
+    sm1.log_command("scan")
+    sm1.log_command("scan")
+    sm1.log_ticket_category("Bug")
+    sm1.log_ticket_category("Feature")
+    sm2 = SessionManager(str(state_file))
+    patterns = sm2.get_work_patterns()
+    assert patterns["commands"]["scan"] == 2
+    assert patterns["categories"]["Bug"] == 1
+    assert patterns["categories"]["Feature"] == 1
+
+
+def test_prompt_uses_work_patterns(monkeypatch, tmp_path):
+    state_file = tmp_path / "state.json"
+    sm = SessionManager(str(state_file))
+    sm.log_ticket_category("Bug")
+    sm.log_ticket_category("Bug")
+    sm.log_ticket_category("Feature")
+
+    captured = {}
+
+    class FakeResponse:
+        def __init__(self, content: str = "analysis"):
+            self.choices = [type("obj", (), {"message": type("msg", (), {"content": content})()})]
+
+    def fake_create(model, messages, temperature):
+        captured["prompt"] = messages[0]["content"]
+        return FakeResponse("BUG-1")
+
+    monkeypatch.setattr(openai.chat.completions, "create", fake_create)
+
+    ticket = Ticket(
+        key="BUG-1",
+        summary="",
+        description="",
+        priority="P1",
+        status="Open",
+        assignee=None,
+        created=datetime.now(),
+        updated=datetime.now(),
+        comments_count=0,
+        labels=[],
+        issue_type="Bug",
+        raw_data={},
+    )
+
+    client = LLMClient(session_manager=sm)
+    client.analyze_workload([ticket])
+
+    assert "The user frequently works on: Bug, Feature" in captured["prompt"]


### PR DESCRIPTION
## Summary
- Track command usage and ticket categories in `work_patterns`
- Use stored work patterns to personalize workload analysis prompts
- Add tests for work pattern persistence and prompt tailoring

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7caabdbc0832b8663a5421ddecd63