### PR TITLE
feat: capture suggestion feedback and use in prompts

### DIFF
--- a/session_manager.py
+++ b/session_manager.py
@@ -19,6 +19,7 @@ class SessionManager:
             "tickets": [],
             "ticket_progress": {},
             "conversation_history": [],
+            "feedback": {},
         }
         self.load()
 
@@ -75,6 +76,19 @@ class SessionManager:
         history.append(message)
         self.save()
 
+    def add_feedback(self, ticket_key: str, context: str, feedback: str) -> None:
+        feedback_store: Dict[str, Dict[str, List[str]]] = self.data.setdefault("feedback", {})
+        ticket_fb: Dict[str, List[str]] = feedback_store.setdefault(ticket_key, {})
+        ctx_key = context.strip()
+        entries: List[str] = ticket_fb.setdefault(ctx_key, [])
+        entries.append(feedback)
+        self.save()
+
+    def get_feedback(self, ticket_key: str, context: str) -> List[str]:
+        feedback_store: Dict[str, Dict[str, List[str]]] = self.data.get("feedback", {})
+        ticket_fb: Dict[str, List[str]] = feedback_store.get(ticket_key, {})
+        return list(ticket_fb.get(context.strip(), []))
+
     def reset(self) -> None:
         self.data.update(
             {
@@ -83,6 +97,7 @@ class SessionManager:
                 "tickets": [],
                 "ticket_progress": {},
                 "conversation_history": [],
+                "feedback": {},
             }
         )
         self.save()

--- a/tests/test_feedback_loops.py
+++ b/tests/test_feedback_loops.py
@@ -1,0 +1,66 @@
+import os
+import unittest
+from datetime import datetime
+from types import SimpleNamespace
+from unittest.mock import patch
+
+from assistant import LLMClient, Ticket, SessionManager
+
+class FeedbackLoopTests(unittest.TestCase):
+    def setUp(self):
+        os.environ["CACHE_FILE"] = "test_cache.json"
+        os.environ["LLM_PROVIDER"] = "openai"
+        self.session_file = "test_session.json"
+        for f in ["test_cache.json", self.session_file]:
+            try:
+                os.remove(f)
+            except FileNotFoundError:
+                pass
+        self.session = SessionManager(self.session_file)
+        self.client = LLMClient(self.session)
+        now = datetime.now()
+        self.ticket = Ticket(
+            key="T1",
+            summary="",
+            description="",
+            priority="P1",
+            status="Open",
+            assignee=None,
+            created=now,
+            updated=now,
+            comments_count=0,
+            labels=[],
+            issue_type="Bug",
+            raw_data={},
+        )
+
+    def tearDown(self):
+        for f in ["test_cache.json", self.session_file]:
+            if os.path.exists(f):
+                os.remove(f)
+        del os.environ["CACHE_FILE"]
+        del os.environ["LLM_PROVIDER"]
+
+    def _mock_resp(self, text: str):
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content=text))])
+
+    def test_positive_feedback_loop(self):
+        with patch("assistant.openai.chat.completions.create", return_value=self._mock_resp("first")):
+            self.client.suggest_action(self.ticket, "ctx")
+        self.session.add_feedback(self.ticket.key, "ctx", "good")
+        with patch("assistant.openai.chat.completions.create", return_value=self._mock_resp("second")) as mock_create:
+            self.client.suggest_action(self.ticket, "ctx", force_refresh=True)
+            prompt = mock_create.call_args[1]["messages"][0]["content"]
+            self.assertIn("good", prompt)
+
+    def test_negative_feedback_loop(self):
+        with patch("assistant.openai.chat.completions.create", return_value=self._mock_resp("first")):
+            self.client.suggest_action(self.ticket, "ctx")
+        self.session.add_feedback(self.ticket.key, "ctx", "bad")
+        with patch("assistant.openai.chat.completions.create", return_value=self._mock_resp("second")) as mock_create:
+            self.client.suggest_action(self.ticket, "ctx", force_refresh=True)
+            prompt = mock_create.call_args[1]["messages"][0]["content"]
+            self.assertIn("bad", prompt)
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- prompt users to rate suggestions as good or bad
- store feedback in session manager and feed it back into LLM prompts
- add tests for positive and negative feedback loops

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7caac9010832bbbcc5baec192f37b