### PR TITLE
Integrate knowledge base for resolved tickets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ build/
 *.pem
 *.crt
 *.cache
+knowledge_base.json
 *.coverage
 *.tox/
 *.mypy_cache/

--- a/knowledge_base.py
+++ b/knowledge_base.py
@@ -1,0 +1,49 @@
+import json
+import os
+from typing import Dict, List
+
+
+class KnowledgeBase:
+    """Simple JSON-backed store for resolved ticket summaries and resolutions."""
+
+    def __init__(self, path: str = "knowledge_base.json") -> None:
+        self.path = path
+        self.data: List[Dict[str, str]] = []
+        self.load()
+
+    def load(self) -> None:
+        if os.path.exists(self.path):
+            try:
+                with open(self.path, "r", encoding="utf-8") as f:
+                    self.data = json.load(f)
+            except Exception:
+                self.data = []
+
+    def save(self) -> None:
+        os.makedirs(os.path.dirname(self.path) or ".", exist_ok=True)
+        with open(self.path, "w", encoding="utf-8") as f:
+            json.dump(self.data, f, indent=2)
+
+    def add(self, ticket_key: str, summary: str, resolution: str) -> None:
+        """Add or update a ticket resolution."""
+        entry = {
+            "ticket_key": ticket_key,
+            "summary": summary,
+            "resolution": resolution,
+        }
+        for idx, existing in enumerate(self.data):
+            if existing.get("ticket_key") == ticket_key:
+                self.data[idx] = entry
+                break
+        else:
+            self.data.append(entry)
+        self.save()
+
+    def search(self, query: str) -> List[Dict[str, str]]:
+        """Return entries whose summary or resolution contain the query."""
+        query = query.lower()
+        return [
+            e
+            for e in self.data
+            if query in e.get("summary", "").lower() or query in e.get("resolution", "").lower()
+        ]

--- a/tests/test_knowledge_base.py
+++ b/tests/test_knowledge_base.py
@@ -1,0 +1,54 @@
+from datetime import datetime
+
+from knowledge_base import KnowledgeBase
+from session_manager import SessionManager
+from assistant import LLMClient, Ticket
+
+
+def test_session_manager_records_done_ticket(tmp_path):
+    kb_file = tmp_path / "kb.json"
+    state_file = tmp_path / "state.json"
+    sm = SessionManager(str(state_file), knowledge_base_path=str(kb_file))
+    ticket = Ticket(
+        key="ABC-1",
+        summary="Fix login bug",
+        description="Restart service",
+        priority="P1",
+        status="In Progress",
+        assignee=None,
+        created=datetime.now(),
+        updated=datetime.now(),
+        comments_count=0,
+        labels=[],
+        issue_type="Bug",
+        raw_data={},
+    )
+    sm.update_session([ticket])
+    ticket.status = "Done"
+    sm.update_session([ticket])
+    kb = KnowledgeBase(str(kb_file))
+    results = kb.search("login")
+    assert any(r["ticket_key"] == "ABC-1" for r in results)
+
+
+def test_llmclient_suggest_action_uses_history(tmp_path):
+    kb_file = tmp_path / "kb.json"
+    kb = KnowledgeBase(str(kb_file))
+    kb.add("ABC-1", "Fix login bug", "Restart service")
+    client = LLMClient(knowledge_base=kb)
+    ticket = Ticket(
+        key="ABC-2",
+        summary="Fix login bug",
+        description="User cannot login",
+        priority="P1",
+        status="Open",
+        assignee=None,
+        created=datetime.now(),
+        updated=datetime.now(),
+        comments_count=0,
+        labels=[],
+        issue_type="Bug",
+        raw_data={},
+    )
+    suggestion = client.suggest_action(ticket, force_refresh=True)
+    assert "Restart service" in suggestion


### PR DESCRIPTION
## Summary
- add JSON-backed knowledge base for saving ticket resolutions
- record completed ticket resolutions in SessionManager and surface similar histories in LLMClient suggestions
- test knowledge base storage and retrieval of historical tickets

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68b7caae2338832ba2922321efd73d0b