### PR TITLE
Preload related ticket context for new prompts

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -488,9 +488,20 @@ Respond in a conversational tone as if talking directly to me. Focus on actionab
             summary=f"You have {len(tickets)} tickets. Focus on {top.key} first - {reasoning}."
         )
     
-    def suggest_action(self, ticket: Ticket, context: str = "", force_refresh: bool = False) -> str:
+    def suggest_action(
+        self,
+        ticket: Ticket,
+        context: str = "",
+        force_refresh: bool = False,
+        related_tickets: Optional[List[Dict[str, str]]] = None,
+    ) -> str:
         """Get AI suggestion for specific ticket action"""
-        cache_key = f"{ticket.key}:{context.strip()}"
+        base_key = f"{ticket.key}:{context.strip()}"
+        if related_tickets:
+            rel_key = ",".join(sorted(t["key"] for t in related_tickets))
+            cache_key = f"{base_key}:{rel_key}"
+        else:
+            cache_key = base_key
         if not force_refresh:
             cached = self.cache.get(cache_key)
             if cached:
@@ -510,11 +521,20 @@ Description: {ticket.description}
 
 Context: {context}
 
-As my work assistant, suggest the most logical next step to move this ticket forward.
-Be specific and actionable. If there are files to download, configs to check, or people to contact, mention them.
-Offer concrete help with execution.
+"""
 
-Keep response conversational and focused on getting this done."""
+        if related_tickets:
+            prompt += "Recently discussed tickets:\n"
+            for rt in related_tickets:
+                prompt += f"- {rt['key']}: {rt['summary']}\n"
+            prompt += "\nUse these for context and reference if helpful.\n"
+
+        prompt += (
+            "As my work assistant, suggest the most logical next step to move this ticket forward.\n"
+            "Be specific and actionable. If there are files to download, configs to check, or people to contact, mention them.\n"
+            "Offer concrete help with execution.\n\n"
+            "Keep response conversational and focused on getting this done."
+        )
 
         try:
             if self.provider == 'openai':
@@ -1112,7 +1132,10 @@ Why it's urgent: {analysis.priority_reasoning}"""
         self.session.set_current_focus(ticket.key)
         self.save_state()
         console.print(f"\n🔍 Focusing on {ticket.key}...")
-        
+
+        related = self.session.get_recent_ticket_summaries(exclude=ticket.key)
+        self.session.record_ticket(ticket)
+
         # Show ticket details with proper description formatting
         details = f"""Summary: {ticket.summary}
 Priority: {ticket.priority} | Status: {ticket.status}
@@ -1123,13 +1146,17 @@ Labels: {', '.join(ticket.labels) if ticket.labels else 'None'}
 
 Description:
 {ticket.description[:500] + '...' if len(ticket.description) > 500 else ticket.description}"""
-        
+
         console.print(Panel(details.strip(), title=f"📋 {ticket.key}", border_style="blue"))
-        
+
+        if related:
+            related_lines = "\n".join(f"{t['key']}: {t['summary']}" for t in related)
+            console.print(Panel(related_lines, title="🔗 Related Tickets", border_style="magenta"))
+
         # Get AI suggestions
         with console.status("[bold green]Getting AI suggestions..."):
-            suggestion = self.llm.suggest_action(ticket)
-        
+            suggestion = self.llm.suggest_action(ticket, related_tickets=related)
+
         console.print(Panel(suggestion, title="🤖 AI Suggestion", border_style="green"))
         
         # Ask for next action

--- a/session_manager.py
+++ b/session_manager.py
@@ -19,6 +19,7 @@ class SessionManager:
             "tickets": [],
             "ticket_progress": {},
             "conversation_history": [],
+            "recent_tickets": [],
         }
         self.load()
 
@@ -75,6 +76,26 @@ class SessionManager:
         history.append(message)
         self.save()
 
+    # Recently focused ticket tracking
+    def record_ticket(self, ticket: Any) -> None:
+        """Store a lightweight summary of a ticket that was recently discussed."""
+        recent: List[Dict[str, str]] = self.data.setdefault("recent_tickets", [])
+        summary = {
+            "key": getattr(ticket, "key", ""),
+            "summary": getattr(ticket, "summary", ""),
+        }
+        recent.append(summary)
+        # Keep only the last 5 entries
+        self.data["recent_tickets"] = recent[-5:]
+        self.save()
+
+    def get_recent_ticket_summaries(self, exclude: Optional[str] = None, limit: int = 3) -> List[Dict[str, str]]:
+        """Return summaries of recently discussed tickets, excluding the provided key."""
+        recent: List[Dict[str, str]] = list(self.data.get("recent_tickets", []))
+        if exclude:
+            recent = [t for t in recent if t.get("key") != exclude]
+        return recent[-limit:]
+
     def reset(self) -> None:
         self.data.update(
             {
@@ -83,6 +104,7 @@ class SessionManager:
                 "tickets": [],
                 "ticket_progress": {},
                 "conversation_history": [],
+                "recent_tickets": [],
             }
         )
         self.save()

--- a/tests/test_related_context.py
+++ b/tests/test_related_context.py
@@ -1,0 +1,54 @@
+import os
+import sys
+from datetime import datetime
+from types import SimpleNamespace
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(__file__)))
+
+from assistant import WorkAssistant, LLMClient, Ticket
+from session_manager import SessionManager
+
+
+def make_ticket(key: str, summary: str) -> Ticket:
+    now = datetime.now()
+    return Ticket(
+        key=key,
+        summary=summary,
+        description="",
+        priority="P1",
+        status="Open",
+        assignee=None,
+        created=now,
+        updated=now,
+        comments_count=0,
+        labels=[],
+        issue_type="Bug",
+        raw_data={},
+    )
+
+
+def test_previous_ticket_context_in_prompt(tmp_path, monkeypatch):
+    monkeypatch.setenv("LLM_PROVIDER", "openai")
+    monkeypatch.setenv("CACHE_FILE", str(tmp_path / "cache.json"))
+    sm = SessionManager(str(tmp_path / "state.json"))
+    client = LLMClient()
+    wa = WorkAssistant(jira_client=None, llm_client=client, session_manager=sm)
+
+    first = make_ticket("T1", "First ticket")
+    second = make_ticket("T2", "Second ticket")
+    wa.current_tickets = [first, second]
+
+    # simulate prior discussion
+    sm.record_ticket(first)
+
+    captured = {}
+
+    def fake_create(model, messages, temperature):
+        captured["prompt"] = messages[0]["content"]
+        return SimpleNamespace(choices=[SimpleNamespace(message=SimpleNamespace(content="ok"))])
+
+    monkeypatch.setattr("assistant.openai.chat.completions.create", fake_create)
+
+    wa._focus_on_ticket("T2")
+
+    assert "T1: First ticket" in captured["prompt"]


### PR DESCRIPTION
## Summary
- Track recently focused tickets in `SessionManager`
- Include recent ticket summaries in LLM prompts and show in focus view
- Add regression test ensuring previous ticket context appears in prompts

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cab0e4f8832b924af75b1abd0929