### PR TITLE
feat: add calendar integration and schedule check

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -20,6 +20,7 @@ import openai
 from dotenv import load_dotenv
 from cache import Cache, SemanticCache
 from session_manager import SessionManager
+from integrations.calendar_client import CalendarClient, CalendarEvent
 
 # Load environment variables
 load_dotenv()
@@ -229,7 +230,7 @@ class LLMClient:
         self._cache_time = None
         self.analysis_cache.clear()
 
-    def analyze_workload(self, tickets: List[Ticket]) -> WorkloadAnalysis:
+    def analyze_workload(self, tickets: List[Ticket], events: Optional[List[CalendarEvent]] = None) -> WorkloadAnalysis:
         """Return cached workload analysis when valid."""
 
         if (
@@ -239,12 +240,12 @@ class LLMClient:
         ):
             return self._analysis_cache
 
-        analysis = self._compute_analysis(tickets)
+        analysis = self._compute_analysis(tickets, events)
         self._analysis_cache = analysis
         self._cache_time = datetime.now()
         return analysis
 
-    def _compute_analysis(self, tickets: List[Ticket]) -> WorkloadAnalysis:
+    def _compute_analysis(self, tickets: List[Ticket], events: Optional[List[CalendarEvent]] = None) -> WorkloadAnalysis:
         """Get AI analysis of your ticket workload"""
         
         # Prepare ticket data for analysis
@@ -263,9 +264,17 @@ class LLMClient:
                 'description': ticket.description[:300] if ticket.description else "No description"
             })
         
+        event_summaries = []
+        for ev in events or []:
+            event_summaries.append({
+                'summary': ev.summary,
+                'start': ev.start.isoformat(),
+                'end': ev.end.isoformat(),
+            })
+
         sorted_tickets = sorted(ticket_summaries, key=lambda t: t['key'])
-        ticket_hash_source = json.dumps(sorted_tickets, sort_keys=True, default=str)
-        ticket_hash = hashlib.sha256(ticket_hash_source.encode('utf-8')).hexdigest()
+        state_hash_source = json.dumps({'tickets': sorted_tickets, 'events': event_summaries}, sort_keys=True, default=str)
+        ticket_hash = hashlib.sha256(state_hash_source.encode('utf-8')).hexdigest()
 
         # Try both caches: file key and semantic (by content)
         cached = None
@@ -296,6 +305,9 @@ class LLMClient:
 
 My tickets:
 {json.dumps(ticket_summaries, indent=2, default=str)}
+
+Upcoming calendar events:
+{json.dumps(event_summaries, indent=2, default=str)}
 
 Please analyze my workload and help me prioritize. Be conversational and helpful, like a smart colleague.
 
@@ -586,22 +598,25 @@ Keep response conversational and focused on getting this done."""
 # ==============================================================================
 
 class WorkAssistant:
-    def __init__(self, jira_client: Optional[JiraClient] = None, llm_client: Optional[LLMClient] = None, session_manager: Optional[SessionManager] = None):
+    def __init__(self, jira_client: Optional[JiraClient] = None, llm_client: Optional[LLMClient] = None, session_manager: Optional[SessionManager] = None, calendar_client: Optional[CalendarClient] = None):
         self.session = session_manager or SessionManager()
         self.jira = jira_client or JiraClient()
         self.llm = llm_client or LLMClient()
+        self.calendar = calendar_client or CalendarClient()
         self.current_tickets: List[Ticket] = []
         self.current_analysis: Optional[WorkloadAnalysis] = None
         self.current_focus: Optional[Ticket] = None
         self.last_user_input: str = ""
         self.analysis_cache: Dict[str, WorkloadAnalysis] = {}
         self.current_ticket_hash: Optional[str] = None
+        self.upcoming_events: List[CalendarEvent] = []
         self.session_cache = Cache()
         self.saved_focus_key: Optional[str] = None
         # Provide a semantic cache here as well for assistant-level caching
         self.semantic_cache = SemanticCache()
         # Default directory for generated files
         self.output_dir = os.getenv('OUTPUT_DIR', 'output')
+        self._next_schedule_check = datetime.now()
 
     def load_state(self):
         """Load persisted session state"""
@@ -614,9 +629,15 @@ class WorkAssistant:
         self.session_manager = SessionManager()
         self.notes: List[str] = []
 
-    def _calculate_ticket_hash(self, tickets: List[Ticket]) -> str:
-        """Create a hash representing the current ticket set"""
-        hash_input = "|".join(sorted(f"{t.key}:{t.updated.isoformat()}" for t in tickets))
+    def _calculate_ticket_hash(self, tickets: List[Ticket], events: Optional[List[CalendarEvent]] = None) -> str:
+        """Create a hash representing the current ticket and calendar state"""
+        ticket_part = "|".join(sorted(f"{t.key}:{t.updated.isoformat()}" for t in tickets))
+        event_part = "|".join(
+            sorted(
+                f"{e.summary}:{e.start.isoformat()}:{e.end.isoformat()}" for e in (events or [])
+            )
+        )
+        hash_input = ticket_part + "#" + event_part
         return hashlib.sha256(hash_input.encode()).hexdigest()
 
     def _ticket_from_dict(self, data: Dict[str, Any]) -> Ticket:
@@ -674,11 +695,14 @@ class WorkAssistant:
             console.print("No open tickets found. Time to take a break! ☕", style="green")
             return
 
+        # Fetch upcoming calendar events
+        self.upcoming_events = self.calendar.get_upcoming_events()
+
         # Record last scan time
         self.session.set_last_scan()
 
-        # Determine ticket hash for caching
-        self.current_ticket_hash = self._calculate_ticket_hash(self.current_tickets)
+        # Determine ticket hash for caching (includes calendar state)
+        self.current_ticket_hash = self._calculate_ticket_hash(self.current_tickets, self.upcoming_events)
 
         # Try to load cached analysis summary
         cached = None
@@ -713,7 +737,7 @@ class WorkAssistant:
             )
         else:
             with console.status("[bold green]Analyzing priorities..."):
-                self.current_analysis = self.llm.analyze_workload(self.current_tickets)
+                self.current_analysis = self.llm.analyze_workload(self.current_tickets, self.upcoming_events)
             # Store in both caches
             cache_payload = {
                 "summary": self.current_analysis.summary,
@@ -823,10 +847,12 @@ Why it's urgent: {analysis.priority_reasoning}"""
             self.current_tickets = self.jira.get_my_tickets()
         self.session.update_session(self.current_tickets)
 
-        with console.status("[bold green]Analyzing priorities..."):
-            self.current_analysis = self.llm.analyze_workload(self.current_tickets)
+        self.upcoming_events = self.calendar.get_upcoming_events()
 
-        self.current_ticket_hash = self._calculate_ticket_hash(self.current_tickets)
+        with console.status("[bold green]Analyzing priorities..."):
+            self.current_analysis = self.llm.analyze_workload(self.current_tickets, self.upcoming_events)
+
+        self.current_ticket_hash = self._calculate_ticket_hash(self.current_tickets, self.upcoming_events)
         try:
             self.analysis_cache.set(self.current_ticket_hash, {"summary": self.current_analysis.summary})
         except Exception:
@@ -842,7 +868,7 @@ Why it's urgent: {analysis.priority_reasoning}"""
         """Handle interactive conversation with the user"""
         console.print("\n" + "="*60)
         console.print("💬 Let's work together! What would you like to do?")
-        console.print("Commands: 'view <ticket>', 'advise <ticket>', 'tickets', 'update <ticket>', 'link <ticket>', 'write <filename>', 'check', 'rescan', 'quit'")
+        console.print("Commands: 'view <ticket>', 'advise <ticket>', 'tickets', 'update <ticket>', 'link <ticket>', 'write <filename>', 'check', 'health', 'rescan', 'quit'")
         console.print("\nQuick picks:")
         top_key = self.current_analysis.top_priority.key if (self.current_analysis and self.current_analysis.top_priority) else None
         if top_key:
@@ -859,6 +885,9 @@ Why it's urgent: {analysis.priority_reasoning}"""
         
         while True:
             try:
+                if datetime.now() >= self._next_schedule_check:
+                    self._schedule_check(auto=True)
+                    self._next_schedule_check = datetime.now() + timedelta(minutes=30)
                 user_input = Prompt.ask("\n[bold blue]What should we tackle?[/bold blue] (press Enter for default)").strip()
                 self.last_user_input = user_input.lower()
                 
@@ -944,7 +973,7 @@ Why it's urgent: {analysis.priority_reasoning}"""
             console.print("🔁 Re-analyzing your workload...")
             self.llm.clear_cache()
             with console.status("[bold green]Analyzing priorities..."):
-                self.current_analysis = self.llm.analyze_workload(self.current_tickets)
+                self.current_analysis = self.llm.analyze_workload(self.current_tickets, self.upcoming_events)
             self._display_analysis()
             return False
         # Numeric shortcut: 4 = choose a ticket by key (prompt)
@@ -965,8 +994,11 @@ Why it's urgent: {analysis.priority_reasoning}"""
             self._create_file(filename)
             return False
 
-        # Health check
-        if input_lower in ['health','check']:
+        # Schedule and health checks
+        if input_lower == 'check':
+            self._schedule_check()
+            return False
+        if input_lower == 'health':
             self._health_check()
             return False
         
@@ -996,7 +1028,7 @@ Why it's urgent: {analysis.priority_reasoning}"""
         if self.current_analysis and self.current_analysis.top_priority:
             top_ticket = self.current_analysis.top_priority.key
             console.print(f"💡 Try: Enter, '1', or 'focus {top_ticket}' to work on your top priority")
-            console.print("Or '2'/'list' to see all your tickets, 'health' for diagnostics")
+            console.print("Or '2'/'list' to see all your tickets, 'check' for schedule, 'health' for diagnostics")
         else:
             console.print("💡 Try: '2'/'list' to see your tickets, or 'help' for available commands")
 
@@ -1013,6 +1045,37 @@ Why it's urgent: {analysis.priority_reasoning}"""
             return
         url = f"{base}/browse/{ticket_key.upper()}"
         console.print(f"🔗 {url}")
+
+    def _schedule_check(self, auto: bool = False) -> str:
+        """Display upcoming events and free slots from the calendar."""
+        events = self.calendar.get_upcoming_events()
+        now = datetime.now()
+        if not events:
+            msg = "No upcoming events. Calendar is clear."
+            if auto:
+                console.print(f"📅 {msg}")
+            else:
+                console.print(Panel(msg, title="📅 Schedule", title_align="left", border_style="magenta"))
+            return msg
+
+        events = sorted(events, key=lambda e: e.start)
+        next_event = events[0]
+        lines = []
+        if next_event.start > now:
+            lines.append(f"Free until {next_event.start.strftime('%H:%M')}")
+        lines.append(f"Next event {next_event.start.strftime('%H:%M')}: {next_event.summary}")
+        last_end = next_event.end
+        for ev in events[1:]:
+            if ev.start - last_end >= timedelta(minutes=30):
+                lines.append(f"Free slot {last_end.strftime('%H:%M')} - {ev.start.strftime('%H:%M')}")
+                break
+            last_end = max(last_end, ev.end)
+        msg = "\n".join(lines)
+        if auto:
+            console.print(f"📅 {msg}")
+        else:
+            console.print(Panel(msg, title="📅 Schedule", title_align="left", border_style="magenta"))
+        return msg
 
     def _health_check(self):
         """Run a quick environment and connectivity check"""

--- a/integrations/calendar_client.py
+++ b/integrations/calendar_client.py
@@ -1,0 +1,57 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import List, Optional
+import requests
+
+
+@dataclass
+class CalendarEvent:
+    """Simple representation of a calendar event."""
+    summary: str
+    start: datetime
+    end: datetime
+
+
+class CalendarClient:
+    """Lightweight Google Calendar client.
+
+    This client uses an API key and calendar ID provided via environment
+    variables to fetch upcoming events. If credentials are missing or an
+    error occurs, it returns an empty list so callers can gracefully handle
+    the absence of calendar data.
+    """
+
+    def __init__(self) -> None:
+        self.api_key = os.getenv("GOOGLE_CALENDAR_API_KEY")
+        self.calendar_id = os.getenv("GOOGLE_CALENDAR_ID", "primary")
+
+    def get_upcoming_events(self, max_results: int = 10) -> List[CalendarEvent]:
+        if not self.api_key:
+            return []
+        url = f"https://www.googleapis.com/calendar/v3/calendars/{self.calendar_id}/events"
+        params = {
+            "key": self.api_key,
+            "timeMin": datetime.utcnow().isoformat() + "Z",
+            "singleEvents": True,
+            "orderBy": "startTime",
+            "maxResults": max_results,
+        }
+        try:
+            resp = requests.get(url, params=params, timeout=5)
+            resp.raise_for_status()
+            data = resp.json()
+            events: List[CalendarEvent] = []
+            for item in data.get("items", []):
+                start_raw = item.get("start", {}).get("dateTime") or item.get("start", {}).get("date")
+                end_raw = item.get("end", {}).get("dateTime") or item.get("end", {}).get("date")
+                if not (start_raw and end_raw):
+                    continue
+                start = datetime.fromisoformat(start_raw.replace("Z", "+00:00"))
+                end = datetime.fromisoformat(end_raw.replace("Z", "+00:00"))
+                events.append(CalendarEvent(summary=item.get("summary", "Busy"), start=start, end=end))
+            return events
+        except Exception:
+            return []

--- a/tests/test_calendar_integration.py
+++ b/tests/test_calendar_integration.py
@@ -1,0 +1,82 @@
+import sys, os
+from datetime import datetime, timedelta
+from io import StringIO
+from unittest.mock import MagicMock, patch
+
+sys.path.append(os.path.dirname(os.path.dirname(__file__)))
+
+from assistant import Ticket, WorkAssistant, WorkloadAnalysis
+from session_manager import SessionManager
+from integrations.calendar_client import CalendarEvent
+
+
+def _make_ticket(key: str) -> Ticket:
+    now = datetime.now()
+    return Ticket(
+        key=key,
+        summary="",
+        description="",
+        priority="P1",
+        status="Open",
+        assignee=None,
+        created=now,
+        updated=now,
+        comments_count=0,
+        labels=[],
+        issue_type="Bug",
+        raw_data={},
+    )
+
+
+def test_events_passed_to_llm(tmp_path):
+    ticket = _make_ticket("T1")
+    jira = MagicMock()
+    jira.get_my_tickets.return_value = [ticket]
+
+    start = datetime.now() + timedelta(hours=1)
+    end = start + timedelta(hours=1)
+    event = CalendarEvent(summary="Meeting", start=start, end=end)
+    calendar = MagicMock()
+    calendar.get_upcoming_events.return_value = [event]
+
+    analysis = WorkloadAnalysis(
+        top_priority=ticket,
+        priority_reasoning="",
+        next_steps=[],
+        can_help_with=[],
+        other_notable=[],
+        summary="summary",
+    )
+    llm = MagicMock()
+    llm.analyze_workload.return_value = analysis
+
+    sm = SessionManager(str(tmp_path / "session.json"))
+    assistant = WorkAssistant(jira_client=jira, llm_client=llm, session_manager=sm, calendar_client=calendar)
+    assistant._display_analysis = MagicMock()
+    assistant._interactive_session = MagicMock()
+
+    with patch("assistant.Confirm.ask", return_value=False):
+        assistant.start_session()
+
+    llm.analyze_workload.assert_called_once()
+    args, kwargs = llm.analyze_workload.call_args
+    assert args[0] == [ticket]
+    assert args[1] == [event]
+
+
+def test_check_command_surfaces_events():
+    start = datetime.now() + timedelta(hours=1)
+    end = start + timedelta(hours=1)
+    event = CalendarEvent(summary="Planning", start=start, end=end)
+    calendar = MagicMock()
+    calendar.get_upcoming_events.return_value = [event]
+
+    assistant = WorkAssistant(jira_client=MagicMock(), llm_client=MagicMock(), calendar_client=calendar)
+
+    from rich.console import Console
+    sio = StringIO()
+    with patch("assistant.console", Console(file=sio)):
+        assistant._handle_user_input("check")
+    output = sio.getvalue()
+    assert "Planning" in output
+    assert "Free until" in output


### PR DESCRIPTION
## Summary
- integrate Google Calendar client to fetch upcoming events
- feed calendar events into workload analysis for time-aware advice
- add `check` command to surface upcoming events or free slots
- cover scheduling logic with new tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b7cab226f0832baa7fb93b96f0c2aa