### PR TITLE
Add FastAPI web entry point

### DIFF
--- a/assistant.py
+++ b/assistant.py
@@ -1,21 +1,14 @@
 #!/usr/bin/env python3
-from rich.console import Console
+import os
 
-from core.work_assistant import WorkAssistant
-
-console = Console()
+import uvicorn
 
 
 def main() -> None:
-    """Entry point for the personal ticket assistant."""
-    try:
-        assistant = WorkAssistant()
-        assistant.start_session()
-    except KeyboardInterrupt:
-        console.print("\n👋 Session ended", style="yellow")
-    except Exception as e:
-        console.print(f"\n❌ Error: {e}", style="red")
+    """Run the web-based ticket assistant."""
+    uvicorn.run("web.app:app", host="0.0.0.0", port=int(os.getenv("PORT", "8000")))
 
 
 if __name__ == "__main__":
     main()
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ openai>=1.3.0
 python-dotenv>=1.0.0
 rich>=13.0.0
 click>=8.0.0
+fastapi>=0.110.0
+uvicorn>=0.23.0

--- a/web/app.py
+++ b/web/app.py
@@ -1,0 +1,16 @@
+from fastapi import FastAPI
+
+from core.work_assistant import WorkAssistant
+
+
+app = FastAPI()
+
+# Initialize a single WorkAssistant instance for the application lifecycle
+assistant = WorkAssistant()
+
+
+@app.post("/api/session/start")
+async def start_session():
+    """Start a new assistant session and return analysis data."""
+    return assistant.start_session_web()
+


### PR DESCRIPTION
## Summary
- replace CLI runner with uvicorn server launcher
- add `start_session_web` to WorkAssistant and expose via FastAPI endpoint
- include FastAPI and Uvicorn dependencies

## Testing
- `pip install fastapi uvicorn`
- `pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68b8d6f33820832baf461a4b92703098